### PR TITLE
Fix typo in annotation processor artifactId

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ dependencies {
     )
 
     kapt(
-        "com.masabi.kotlinbuilder:kotlinbuilder-processor:$kotlinbuilderVersion"
+        "com.masabi.kotlinbuilder:masabi-kotlinbuilder-processor:$kotlinbuilderVersion"
     )
 }
 ```


### PR DESCRIPTION
Thanks for this project! Just noticed there is a slight typo in the `README`